### PR TITLE
Add configurable etcd URL and discovery URL

### DIFF
--- a/handlers/token.go
+++ b/handlers/token.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 
 	"github.com/coreos/discovery.etcd.io/pkg/lockstring"
@@ -18,7 +19,12 @@ var (
 )
 
 func init() {
-	currentLeader.Set("127.0.0.1:4001")
+	init_leader := os.Getenv("DISCOVERY_INIT_LEADER")
+	if init_leader == "" {
+		currentLeader.Set("127.0.0.1:4001")
+	} else {
+		currentLeader.Set(init_leader)
+	}
 }
 
 func proxyRequest(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
This is the first half (san-Dockerfile) to allow folks to specify an alternate ETCD cluster to join (other than localhost:4001) and be hosted on a domain other than discovery.etdc.io