### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.3.3
+
+RUN mkdir /srv/discovery
+
+EXPOSE 8087
+
+ADD . /srv/discovery
+RUN cd /srv/discovery && ./build
+CMD cd /srv/discovery && ./devweb


### PR DESCRIPTION
```
docker build -t discovery .
```

assuming etcd is running in another container, but exposing 4001 and 7001 publicly:

```
IMAGE=discovery
PUBLIC_IP=$(ip addr show eth0 | awk 'NR==3{print $2}' | awk -F'/' '{print $1}')
docker run -d -p 80:8087 -e DISCOVERY_ROOT_URL=http://$(hostname -f):4001/v2/keys/_etcd/registry/ -e DISCOVERY_ORIGIN_ADDR=http://$PUBLIC_IP:4001 -e DISCOVERY_INIT_LEADER=$PUBLIC_IP:7001 $IMAGE
```

then you can run:

```
curl localhost/new
```