### PR TITLE
Removed https://discovery.../ from handlers/new.go

### DIFF
--- a/handlers/new.go
+++ b/handlers/new.go
@@ -78,5 +78,5 @@ func NewTokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("New cluster created", token)
 
-	fmt.Fprintf(w, "https://discovery.etcd.io/"+token)
+	fmt.Fprintf(w, token)
 }


### PR DESCRIPTION
I think is better to be more flexible not displaying at all the base of the URL when you request a new token