### PR TITLE
http: Allow configuration of the URI from /new

### DIFF
--- a/handlers/new.go
+++ b/handlers/new.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/coreos/go-etcd/etcd"
 )
+
+var baseURI = flag.String("host", "https://discovery.etcd.io", "base location for computed token URI")
 
 func generateCluster() string {
 	b := make([]byte, 16)
@@ -78,5 +81,5 @@ func NewTokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("New cluster created", token)
 
-	fmt.Fprintf(w, "https://discovery.etcd.io/"+token)
+	fmt.Fprintf(w, "%s/%s", *baseURI, token)
 }

--- a/handlers/new.go
+++ b/handlers/new.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -81,5 +82,5 @@ func NewTokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Println("New cluster created", token)
 
-	fmt.Fprintf(w, "%s/%s", *baseURI, token)
+	fmt.Fprintf(w, "%s/%s", bytes.TrimRight([]byte(*baseURI), "/"), token)
 }


### PR DESCRIPTION
This patch adds a new flag, `--host`, which permits runtime
configuration of the URI returned by the `/new` handler. The default
behavior is the current hardcoded behavior, which always directs clients
to https://discovery.etcd.io.

Example usage:

    bin/discovery.etcd.io --host=https://discovery.example.com

The given string will be used verbatim and is not parsed. It is
completely possible to return malformed URIs if not careful.

Future work should perhaps react to the Host header, but further study
is needed regarding the ELB CoreOS uses in production; at the very
least, TLS should be preferred, so the Host header might not always be
the best default for this purpose.

Fixes: #3
Cc: @brianredbeard