### PR TITLE
handlers: Add /robots.txt

### DIFF
--- a/handlers/robots.go
+++ b/handlers/robots.go
@@ -1,0 +1,10 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func RobotsHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "User-agent: *\nDisallow: /")
+}

--- a/http/http.go
+++ b/http/http.go
@@ -16,6 +16,7 @@ func init() {
 	r.HandleFunc("/", handlers.HomeHandler)
 	r.HandleFunc("/new", handlers.NewTokenHandler)
 	r.HandleFunc("/health", handlers.HealthHandler)
+	r.HandleFunc("/robots.txt", handlers.RobotsHandler)
 
 	// Only allow exact tokens with GETs and PUTs
 	r.HandleFunc("/{token:[a-f0-9]{32}}", handlers.TokenHandler).


### PR DESCRIPTION
I've seen `/new` pop up in Google results, and there's nothing of value
to crawl here anyway. Prevent all nice robots from snooping around,
especially from tutorial URLs.