### PR TITLE
docker: Support ENTRYPOINT and trim container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM golang:onbuild
+FROM scratch
+MAINTAINER "CoreOS, Inc"
 EXPOSE 8087
 
-ADD . /srv/discovery.etcd.io
-WORKDIR /srv/discovery.etcd.io
+# You need to build bin/discovery-linux64-static first; check build-static.
 
-CMD GOPATH="${PWD}/third_party" ./devweb -addr=":8087" github.com/coreos/discovery.etcd.io/discovery
+ADD bin/discovery-linux64-static /discovery
+
+CMD ["--addr=:8087"]
+ENTRYPOINT ["/discovery"]

--- a/build-docker
+++ b/build-docker
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+# build discovery statically for the docker container, then build the container
+
+cat >.payload <<EOF
+go run third_party.go clean -i net
+go run third_party.go install -tags netgo std
+CGO_ENABLED=0 go run third_party.go build -a -tags netgo --ldflags '-w -extldflags=-static' -o bin/discovery-linux64-static github.com/coreos/discovery.etcd.io
+EOF
+
+echo "building statically-linked discovery.etcd.io..."
+docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:latest bash .payload
+rm -f .payload
+
+echo "building docker container..."
+docker build .


### PR DESCRIPTION
Add a new script, `build-docker`; this builds the `discovery.etcd.io` binary
statically by hacking up Docker's `gobuild:latest` image. We go through Docker
unconditionally so the standard library hackery doesn't bleed into user Golang.

The workflow for building a Docker image looks like this now:

    $ ./build-docker
    Successfully built 223dc924df08

The new Dockerfile form should behave like a straight binary with the new
support for ENTRYPOINT, as well:

    $ docker run -d 223dc924df08 --addr=127.0.0.1:8087 --host=http://disc.example.com
    45a159c334cabd753148f543bd5268866f9183d98f135acb4b54892c891e173b

    $ curl http://127.0.0.1:8087/new
    http://disc.example.com/b3f04b132a74a5620de41ebb34c84fad

This workflow does not modify the `build` and `devweb` flows.