### PR TITLE
handlers: flush header before copying body

### DIFF
--- a/handlers/token.go
+++ b/handlers/token.go
@@ -81,5 +81,6 @@ func TokenHandler(w http.ResponseWriter, r *http.Request) {
 
 	copyHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
+	w.(http.Flusher).Flush()
 	io.Copy(w, resp.Body)
 }

--- a/handlers/token.go
+++ b/handlers/token.go
@@ -26,9 +26,9 @@ func proxyRequest(r *http.Request) (*http.Response, error) {
 
 	for i := 0; i <= 10; i++ {
 		u := url.URL{
-			Scheme: "http",
-			Host: currentLeader.String(),
-			Path: path.Join("v2", "keys", "_etcd", "registry", r.URL.Path),
+			Scheme:   "http",
+			Host:     currentLeader.String(),
+			Path:     path.Join("v2", "keys", "_etcd", "registry", r.URL.Path),
 			RawQuery: r.URL.RawQuery,
 		}
 

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -1,0 +1,176 @@
+package http
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+	"unicode/utf8"
+)
+
+// This handler borrowed from github.com/gorilla/handlers
+
+// loggingHandler is the http.Handler implementation for LoggingHandlerTo and its friends
+type loggingHandler struct {
+	writer  io.Writer
+	handler http.Handler
+}
+
+func (h loggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	t := time.Now()
+	logger := &responseLogger{w: w}
+	url := *req.URL
+	h.handler.ServeHTTP(logger, req)
+	writeLog(h.writer, req, url, t, logger.Status(), logger.Size())
+}
+
+// responseLogger is wrapper of http.ResponseWriter that keeps track of its HTTP status
+// code and body size
+type responseLogger struct {
+	w      http.ResponseWriter
+	status int
+	size   int
+}
+
+func (l *responseLogger) Header() http.Header {
+	return l.w.Header()
+}
+
+func (l *responseLogger) Write(b []byte) (int, error) {
+	if l.status == 0 {
+		// The status will be StatusOK if WriteHeader has not been called yet
+		l.status = http.StatusOK
+	}
+	size, err := l.w.Write(b)
+	l.size += size
+	return size, err
+}
+
+func (l *responseLogger) WriteHeader(s int) {
+	l.w.WriteHeader(s)
+	l.status = s
+}
+
+func (l *responseLogger) Status() int {
+	return l.status
+}
+
+func (l *responseLogger) Size() int {
+	return l.size
+}
+
+const lowerhex = "0123456789abcdef"
+
+func appendQuoted(buf []byte, s string) []byte {
+	var runeTmp [utf8.UTFMax]byte
+	for width := 0; len(s) > 0; s = s[width:] {
+		r := rune(s[0])
+		width = 1
+		if r >= utf8.RuneSelf {
+			r, width = utf8.DecodeRuneInString(s)
+		}
+		if width == 1 && r == utf8.RuneError {
+			buf = append(buf, `\x`...)
+			buf = append(buf, lowerhex[s[0]>>4])
+			buf = append(buf, lowerhex[s[0]&0xF])
+			continue
+		}
+		if r == rune('"') || r == '\\' { // always backslashed
+			buf = append(buf, '\\')
+			buf = append(buf, byte(r))
+			continue
+		}
+		if strconv.IsPrint(r) {
+			n := utf8.EncodeRune(runeTmp[:], r)
+			buf = append(buf, runeTmp[:n]...)
+			continue
+		}
+		switch r {
+		case '\a':
+			buf = append(buf, `\a`...)
+		case '\b':
+			buf = append(buf, `\b`...)
+		case '\f':
+			buf = append(buf, `\f`...)
+		case '\n':
+			buf = append(buf, `\n`...)
+		case '\r':
+			buf = append(buf, `\r`...)
+		case '\t':
+			buf = append(buf, `\t`...)
+		case '\v':
+			buf = append(buf, `\v`...)
+		default:
+			switch {
+			case r < ' ':
+				buf = append(buf, `\x`...)
+				buf = append(buf, lowerhex[s[0]>>4])
+				buf = append(buf, lowerhex[s[0]&0xF])
+			case r > utf8.MaxRune:
+				r = 0xFFFD
+				fallthrough
+			case r < 0x10000:
+				buf = append(buf, `\u`...)
+				for s := 12; s >= 0; s -= 4 {
+					buf = append(buf, lowerhex[r>>uint(s)&0xF])
+				}
+			default:
+				buf = append(buf, `\U`...)
+				for s := 28; s >= 0; s -= 4 {
+					buf = append(buf, lowerhex[r>>uint(s)&0xF])
+				}
+			}
+		}
+	}
+	return buf
+
+}
+
+// buildCommonLogLine builds a log entry for req in Apache Common Log Format.
+// ts is the timestamp with which the entry should be logged.
+// status and size are used to provide the response HTTP status and size.
+func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int, size int) []byte {
+	username := "-"
+	if url.User != nil {
+		if name := url.User.Username(); name != "" {
+			username = name
+		}
+	}
+
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+
+	if err != nil {
+		host = req.RemoteAddr
+	}
+
+	uri := url.RequestURI()
+
+	buf := make([]byte, 0, 3*(len(host)+len(username)+len(req.Method)+len(uri)+len(req.Proto)+50)/2)
+	buf = append(buf, host...)
+	buf = append(buf, " - "...)
+	buf = append(buf, username...)
+	buf = append(buf, " ["...)
+	buf = append(buf, ts.Format("02/Jan/2006:15:04:05 -0700")...)
+	buf = append(buf, `] "`...)
+	buf = append(buf, req.Method...)
+	buf = append(buf, " "...)
+	buf = appendQuoted(buf, uri)
+	buf = append(buf, " "...)
+	buf = append(buf, req.Proto...)
+	buf = append(buf, `" `...)
+	buf = append(buf, strconv.Itoa(status)...)
+	buf = append(buf, " "...)
+	buf = append(buf, strconv.Itoa(size)...)
+	return buf
+}
+
+// writeLog writes a log entry for req to w in Apache Common Log Format.
+// ts is the timestamp with which the entry should be logged.
+// status and size are used to provide the response HTTP status and size.
+func writeLog(w io.Writer, req *http.Request, url url.URL, ts time.Time, status, size int) {
+	buf := buildCommonLogLine(req, url, ts, status, size)
+	buf = append(buf, '\n')
+	w.Write(buf)
+}

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -61,6 +61,10 @@ func (l *responseLogger) Size() int {
 	return l.size
 }
 
+func (l *responseLogger) Flush() {
+	l.w.(http.Flusher).Flush()
+}
+
 const lowerhex = "0123456789abcdef"
 
 func appendQuoted(buf []byte, s string) []byte {

--- a/http/http.go
+++ b/http/http.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"os"
 
-	gorillaHandlers "github.com/gorilla/handlers"
-
 	"github.com/coreos/discovery.etcd.io/handlers"
 	"github.com/gorilla/mux"
 )
@@ -28,7 +26,7 @@ func init() {
 	r.HandleFunc("/{token:[a-f0-9]{32}}/_config/size", handlers.TokenHandler).
 		Methods("GET")
 
-	logH := gorillaHandlers.LoggingHandler(os.Stdout, r)
+	logH := loggingHandler{writer: os.Stdout, handler: r}
 
 	http.Handle("/", logH)
 }


### PR DESCRIPTION
This helps watch to return HTTP response header first, so client could
know that the watch is happening.

Move the code from github.com/gorilla/handlers.loggingHandler into http pkg so i could add flush support on it. The reasons of move are two: 1. the repo has discussion about adding flush support, but ends up with no changes 2. the thing needs to be fixed before 2.1 release.

The watch now:

```
$ curl -v http://localhost:8000/9d7d774171b8b979294132884acbd2f8\?wait\=true
* Hostname was NOT found in DNS cache
*   Trying ::1...
* connect to ::1 port 8000 failed: Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /9d7d774171b8b979294132884acbd2f8?wait=true HTTP/1.1
> User-Agent: curl/7.39.0
> Host: localhost:8000
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Tue, 14 Jul 2015 04:51:59 GMT
< X-Etcd-Cluster-Id: 7e27652122e8b2ae
< X-Etcd-Index: 5
< X-Raft-Index: 7492
< X-Raft-Term: 2
< Transfer-Encoding: chunked
<

```

fixes #32 
helps https://github.com/coreos/etcd/issues/3126
