### PR TITLE
add parsing of etcd and host arguments

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -21,14 +21,14 @@ func fail(err string) {
 	os.Exit(2) // default go flag error code
 }
 
-func getValidUrlOrExit(givenUrl string) string {
+func mustHostOnlyURL(givenUrl string) string {
 	u, err := url.Parse(givenUrl)
 
 	if err != nil {
 		fail(fmt.Sprintf("Invalid url given: %v", err))
 	}
 
-	if len(u.Path) > 1 || (len(u.Path) == 1 && u.Path != "/") {
+	if len(u.Path) != 0 && u.Path != "/" {
 		fail(fmt.Sprintf("Expected url without path (%v)", u.Path))
 	}
 
@@ -64,10 +64,10 @@ func init() {
 
 func main() {
 	log.SetFlags(0)
-	viper.Set("etcd", getValidUrlOrExit(viper.GetString("etcd")))
-	viper.Set("host", getValidUrlOrExit(viper.GetString("host")))
+	etcdHost := mustHostOnlyURL(viper.GetString("etcd"))
+	discHost := mustHostOnlyURL(viper.GetString("host"))
 
-	handling.Setup()
+	handling.Setup(etcdHost, discHost)
 
 	err := http.ListenAndServe(viper.GetString("addr"), nil)
 	if err != nil {

--- a/handlers/new.go
+++ b/handlers/new.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 	"time"
@@ -50,6 +51,9 @@ func Setup() {
 		// set timeout per request to fail fast when the target endpoint is unavailable
 		HeaderTimeoutPerRequest: time.Second,
 	}
+
+	u, _ := url.Parse(viper.GetString("etcd"))
+	currentLeader.Set(u.Host)
 }
 
 func setupToken(size int) (string, error) {

--- a/handlers/token.go
+++ b/handlers/token.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coreos/discovery.etcd.io/handlers/httperror"
 	"github.com/coreos/discovery.etcd.io/pkg/lockstring"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/viper"
 )
 
 func init() {
@@ -26,8 +25,6 @@ func init() {
 		[]string{"code", "method"},
 	)
 	prometheus.MustRegister(tokenCounter)
-
-	currentLeader.Set(viper.GetString("etcd"))
 }
 
 var (

--- a/http/http.go
+++ b/http/http.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func Setup() {
-	handlers.Setup()
+func Setup(etcdHost, discHost string) {
+	handlers.Setup(etcdHost, discHost)
 	r := mux.NewRouter()
 
 	r.HandleFunc("/", handlers.HomeHandler)


### PR DESCRIPTION
based on https://github.com/coreos/discovery.etcd.io/pull/27

add parsing of `etcd` and `host` parameters.

I'm not sure how I feel about the exiting pattern, but any other way will be less clean and involve branching in the `main()` function. Thoughts?