### PR TITLE
move metrics to their own port

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -5,14 +5,14 @@ import (
 	"os"
 
 	gorillaHandlers "github.com/gorilla/handlers"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/coreos/discovery.etcd.io/handlers"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gorilla/mux"
 )
 
-func Setup(etcdHost, discHost string) {
+func Setup(etcdHost, discHost string) (http.Handler, http.Handler) {
 	handlers.Setup(etcdHost, discHost)
 	r := mux.NewRouter()
 
@@ -31,8 +31,7 @@ func Setup(etcdHost, discHost string) {
 	r.HandleFunc("/{token:[a-f0-9]{32}}/_config/size", handlers.TokenHandler).
 		Methods("GET")
 
-	logH := gorillaHandlers.LoggingHandler(os.Stdout, r)
-
-	http.Handle("/", logH)
-	http.Handle("/metrics", prometheus.Handler())
+	loggedHandler := gorillaHandlers.LoggingHandler(os.Stdout, r)
+	prometheusHandler := prometheus.Handler()
+	return loggedHandler, prometheusHandler
 }


### PR DESCRIPTION
go can't run two http servers at once, so we split metrics into
its own gothread. the prometheus handler needs to be instantiated
before the gothread is split (so no
http.ListenAndServe(":8088", prometheus.Handler())
), as it would be split apart from the thread containing the collected
data.

the handlers.Setup() function now returns two handlers to allow this.

fixes #50 